### PR TITLE
Switch from test.pypi to pypi for publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,8 +49,7 @@ jobs:
 
       - name: Build and Publish
         env:
-            TEST_PYPI_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
+            PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         run: |
-            poetry config pypi-token.test-pypi $TEST_PYPI_TOKEN
-            poetry config repositories.test-pypi https://test.pypi.org/legacy/
-            poetry publish --build --repository test-pypi
+            poetry config pypi-token.pypi $PYPI_TOKEN
+            poetry publish --build --repository pypi


### PR DESCRIPTION
just that.

PyPI is used by default, so no configuration needed.