### PR TITLE
Use dir name as upload name when creating a .tar.gz upload from a specified directory

### DIFF
--- a/src/sindri_labs/sindri.py
+++ b/src/sindri_labs/sindri.py
@@ -1,6 +1,7 @@
 import io
 import json
 import os
+import pathlib
 import tarfile
 import time
 from pprint import pformat
@@ -211,9 +212,10 @@ class Sindri:
         elif os.path.isdir(circuit_upload_path):
             # Create a tar archive and upload via byte stream
             circuit_upload_path = os.path.abspath(circuit_upload_path)
+            file_name = f"{pathlib.Path(circuit_upload_path).stem}.tar.gz"
             fh = io.BytesIO()
             with tarfile.open(fileobj=fh, mode="w:gz") as tar:
-                tar.add(circuit_upload_path, arcname="upload.tar.gz")
+                tar.add(circuit_upload_path, arcname=file_name)
             files = {"files": fh.getvalue()}  # type: ignore
 
         # 1. Create a circuit, obtain a circuit_id.


### PR DESCRIPTION
This PR enables detecting the dir name to be used as uploaded file name when creating an in-memory .tar.gz upload from a specified directory. Prior to this update, we provided a generic name "upload.tar.gz".

The Sindri API now stores the name of the uploaded file as metadata. The name of the uploaded file is useful context for the user.

### Example of the change
In the following [code block](https://github.com/Sindri-Labs/sindri-resources/blob/c5bb0bde2ef1edddcf39b6ac4a6d1cb0efc1752c/reference_code/sdk_quickstart.py#L12-L14) that uses this SDK,
the resulting `"uploaded_file_name"` in the CircuitInfoResponse from the Sindri API would always be set as `upload.tar.gz`. Now, [this update](https://github.com/Sindri-Labs/sindri-python/pull/4/files#diff-3236f45dbcd9bfb10ca3e97d392e8d030371364460c117fbe93303fb3ed34fbaR218) to the Sindri Python SKD allows the name of the uploaded file to be detected from the directory name and we instead get `multiplier2.tar.gz`.

