### PR TITLE
Add test.pypi build option to CI GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,8 +84,8 @@ jobs:
 
       - name: Build and Publish
         env:
-            PYPI_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
+            TEST_PYPI_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
         run: |
-            poetry config pypi-token.pypi $PYPI_TOKEN
+            poetry config pypi-token.test-pypi $TEST_PYPI_TOKEN
             poetry config repositories.test-pypi https://test.pypi.org/legacy/
             poetry publish --build --repository test-pypi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
 
   build_and_publish:
     runs-on: ubuntu-latest
+    # Only run this workflow if the tag starts with "v"
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     needs: [lint]
     steps:
@@ -59,6 +60,7 @@ jobs:
 
   build_and_publish_test:
     runs-on: ubuntu-latest
+    # Only run this workflow if the tag starts with "test-v"
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/test-v')
     needs: [lint]
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,21 +5,23 @@ on:
     branches: ["main"]
     tags:
       - "v*"
+      - "test-v*"
   pull_request:
 
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      # - name: Checkout code
+      #   uses: actions/checkout@v4
 
-      - name: Set Up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
+      # - name: Set Up Python
+      #   uses: actions/setup-python@v4
+      #   with:
+      #     python-version: '3.10'
 
       - name: Linting
+        # TODO: uncomment above steps for checking out the code and setting up python when Linting is implemented.
         run: echo "black, isort, flake8, mypy still to come..."
 
   build_and_publish:
@@ -53,3 +55,37 @@ jobs:
         run: |
             poetry config pypi-token.pypi $PYPI_TOKEN
             poetry publish --build
+
+
+  build_and_publish_test:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/test-v')
+    needs: [lint]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set Up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Extract Version from Tag
+        run: echo "VERSION=${GITHUB_REF#refs/tags/test-v}" >> $GITHUB_ENV
+
+      - name: Install poetry
+        run: pip install poetry
+
+      - name: Install Dependencies
+        run: poetry install
+
+      - name: Update project.toml Version
+        run: poetry version $VERSION
+
+      - name: Build and Publish
+        env:
+            PYPI_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        run: |
+            poetry config pypi-token.pypi $PYPI_TOKEN
+            poetry config repositories.test-pypi https://test.pypi.org/legacy/
+            poetry publish --build --repository test-pypi


### PR DESCRIPTION
# Add test.pypi build option to CI GitHub Action

How the new CI action works:
On a push to main or any pull request, or any tag that starts with `v` or `test-v`
- Run the `Lint` check (currently does nothing) 

On any tag that starts with `v`
- Build and publish to the **official** PyPI repo: https://pypi.org/project/sindri-labs/. If the tag is `v2.3.4`, the version on the published pypi repo drops the `v` and becomes `2.3.4`

On any tag that starts with `test-v`
- Build and publish to the **test** PyPI repo: https://test.pypi.org/project/sindri-labs/. If the tag is `test-v2.3.4`, the version on the published pypi repo drops the `test-v` and becomes `2.3.4`