### PR TITLE
Change default API Url to the new production URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,19 @@
 # Sindri Python SDK
 
+***This SDK is an alpha (testing) release and may change at any time.***
+
 ## Build Status
 
 ![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/sindri-labs/sindri-python/ci.yml?style=for-the-badge)
 
 ## Description
 The Sindri Python SDK.
-Contains SDK code for Sindri APIs. Please see [Sindri.app](https://sindri.app) for more details.
+Contains SDK code for Sindri APIs. Please see [sindri.app](https://sindri.app) for more details.
 
-This SDK is an alpha (testing) release and may change at any time.
-
-## Usage
-
-### Prove An Existing Circuit
-```
-from sindri_labs.sindri import Sindri
-sindri = Sindri('api_key')
-with open('./anonklub-circom/input.json', 'r') as file:
-    sindri.prove_circuit('7c2c5e9d-235b-40ef-9c6a-694e6a2dc034', file.read())
-```
+## Documentation and Usage
+Documentation for this repo is automatically generated from the Python docstrings using [lazydocs](https://pypi.org/project/lazydocs/) and published to [sindri.app/docs/reference/sdk/](https://sindri.app/docs/reference/sdk/) along with the rest of the documentation for Sindri.
 
 ## License
 [![](https://img.shields.io/github/license/sindri-labs/sindri-python?style=for-the-badge)](https://img.shields.io/github/license/sindri-labs/sindri-python?style=for-the-badge)
 
-sindri-python is licensed under a [MIT License](LICENSE) and is copyright [Sindri Labs, LLC](https://sindri.app).
+`sindri-python` is licensed under a [MIT License](LICENSE) and is copyright [Sindri Labs, Inc.](https://sindri.app).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 description = "Sindri Python SDK"
-homepage = "https://forge.sindri.app"
+homepage = "https://sindri.app"
 license = "MIT"
 name = "sindri-labs"
 readme = "README.md"

--- a/src/sindri_labs/sindri.py
+++ b/src/sindri_labs/sindri.py
@@ -41,7 +41,7 @@ class Sindri:
 
         pass
 
-    DEFAULT_SINDRI_API_URL = "https://forge.sindri.app/api/"
+    DEFAULT_SINDRI_API_URL = "https://sindri.app/api/"
     API_VERSION = "v1"
 
     def __init__(
@@ -538,7 +538,7 @@ class Sindri:
         Set the API Url for the Sindri instance.
 
         NOTE: `v1/` is appended to the Sindri API Url if it is not present.
-        - Example: `https://forge.sindri.app/api/` becomes `https://forge.sindri.app/api/v1/`
+        - Example: `https://sindri.app/api/` becomes `https://sindri.app/api/v1/`
         """
         if not isinstance(api_url, str):
             raise Sindri.APIError("Invalid API Url")


### PR DESCRIPTION
Change https://forge.sindri.app to https://sindri.app to support our updated URLs

Sindri Labs is phasing out the API Url that we used for our prototype and moving towards our production URLs.

Other:
- Update README.md: Resolves #9 