### PR TITLE
Supply github_ref as $TAG for lazydocs --src-base-url

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
       - run: |
           pip install requests>=2.13.0 lazydocs
       - run: |
-          ./build-docs.sh
+          TAG=${{ github.ref_name }} ./build-docs.sh
 
       - name: 'Save Generated Markdown'
         uses: actions/upload-artifact@v3

--- a/build-docs.sh
+++ b/build-docs.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 mkdir -p docs/docstrings
 
+TAG="${TAG:-main}"
+
 # pip install requests>=2.13.0 lazydocs
 lazydocs \
     --output-path="docs/docstrings" \
     --overview-file="README.md" \
-    --src-base-url="https://github.com/Sindri-Labs/sindri-python/blob/main/" \
+    --src-base-url="https://github.com/Sindri-Labs/sindri-python/blob/$TAG/" \
     --no-watermark \
     src/sindri_labs

--- a/local-run-docs.sh
+++ b/local-run-docs.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
 mkdir -p docs/docstrings
 
+
+TAG="${TAG:-main}"
+
 # pip install requests>=2.13.0 lazydocs
 lazydocs \
     --output-path="./docs/docstrings" \
     --overview-file="README.md" \
-    --src-base-url="https://github.com/Sindri-Labs/sindri-python/blob/main/" \
+    --src-base-url="https://github.com/Sindri-Labs/sindri-python/blob/$TAG/" \
     --no-watermark \
     src/sindri_labs
 


### PR DESCRIPTION
Supply github_ref as $TAG for lazydocs `--src-base-url`

The generated `lazydocs` will now have the correct github reference for its `href`s.

Prior to this PR, all hrefs in the docs pointed to the `main` branch when linking to code lines in this repo. This was unstable since links to code lines should always point to commit hashes or tags, not branches.