### PR TITLE
Change the perform_verify_check in the prove to default to False

### DIFF
--- a/src/sindri_labs/sindri.py
+++ b/src/sindri_labs/sindri.py
@@ -64,7 +64,7 @@ class Sindri:
 
         self.polling_interval_sec: int = 1  # polling interval for circuit compilation & proving
         self.max_polling_iterations: int = 172800  # 2 days with polling interval 1 second
-        self.perform_verify: bool = True
+        self.perform_verify: bool = False
         self.set_api_url(api_url)
         self.set_api_key(api_key)
 


### PR DESCRIPTION
Change the perform_verify_check in the prove to default to False

The Sindri API [Create Proof](https://sindri.app/docs/reference/api/proof-create/) endpoint supports the optional flag `perform_verify: bool`. This change sets the SDK default to `False` to match the API endpoint default. 

An SDK user can still perform the verify check for proofs by altering the class variable of their SDK instance:
```python
# Run Sindri API
API_KEY = <YOUR_API_KEY>
sindri = Sindri(API_KEY)
sindri.perform_verify = True  # ------- here
circuit_id = sindri.create_circuit(circuit_upload_path)
proof_id = sindri.prove_circuit(circuit_id, proof_input)
```