### PR TITLE
Add more methods and unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,7 @@ ENV/
 env.bak/
 venv.bak/
 
+
 # Spyder project settings
 .spyderproject
 .spyproject

--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ Documentation for this repo is automatically generated from the Python docstring
 `sindri-python` is licensed under a [MIT License](LICENSE) and is copyright [Sindri Labs, Inc.](https://sindri.app).
 
 ## Unit Tests
-See `tests/README.md` for more information.
+See [`tests/README.md`](tests/README.md) for more information.

--- a/README.md
+++ b/README.md
@@ -17,3 +17,6 @@ Documentation for this repo is automatically generated from the Python docstring
 [![](https://img.shields.io/github/license/sindri-labs/sindri-python?style=for-the-badge)](https://img.shields.io/github/license/sindri-labs/sindri-python?style=for-the-badge)
 
 `sindri-python` is licensed under a [MIT License](LICENSE) and is copyright [Sindri Labs, Inc.](https://sindri.app).
+
+## Unit Tests
+See `tests/README.md` for more information.

--- a/src/sindri/sindri.py
+++ b/src/sindri/sindri.py
@@ -123,12 +123,12 @@ class Sindri:
         try:
             if method == "POST":
                 response = requests.post(
-                    full_path, headers=self.headers_json, data=data, files=files, verify=False
+                    full_path, headers=self.headers_json, data=data, files=files
                 )
             elif method == "GET":
-                response = requests.get(full_path, headers=self.headers_json, params=data, verify=False)
+                response = requests.get(full_path, headers=self.headers_json, params=data)
             elif method == "DELETE":
-                response = requests.delete(full_path, headers=self.headers_json, data=data, verify=False)
+                response = requests.delete(full_path, headers=self.headers_json, data=data)
             else:
                 raise Sindri.APIError("Invalid request method")
         except requests.exceptions.ConnectionError:
@@ -353,35 +353,29 @@ class Sindri:
         # Circuit compilation success!
         return circuit_id
 
-    def delete_circuit(
-        self, circuit_id: str
-    ) -> tuple[int, dict | list]:
+    def delete_circuit(self, circuit_id: str) -> None:
         """
         Delete a circuit by hitting the `/circuit/<circuit_id>/delete` endpoint.
         This also deletes all of the circuit's proofs.
 
-        Return the `response.status_code` and the JSON decoded `response`.
-        This may raise `Sindri.APIError`.
-        This does not check if the `response.status_code` is the successful response (200).
+        Returns `None` if the deletion was successful. Else, raise `Sindri.APIError`.
         """
-        response_status_code, response_json =  self._hit_api("DELETE", f"circuit/{circuit_id}/delete")
+        response_status_code, response_json = self._hit_api(
+            "DELETE", f"circuit/{circuit_id}/delete"
+        )
         if response_status_code != 200:
             raise Sindri.APIError(
                 f"Unable to delete circuit_id={circuit_id}."
                 f" status={response_status_code} response={response_json}"
             )
 
-    def delete_proof(
-        self, proof_id: str
-    ) -> tuple[int, dict | list]:
+    def delete_proof(self, proof_id: str) -> None:
         """
         Delete a proof by hitting the `/proof/<proof_id>/delete` endpoint.
 
-        Return the `response.status_code` and the JSON decoded `response`.
-        This may raise `Sindri.APIError`.
-        This does not check if the `response.status_code` is the successful response (200).
+        Returns `None` if the deletion was successful. Else, raise `Sindri.APIError`.
         """
-        response_status_code, response_json =  self._hit_api("DELETE", f"proof/{proof_id}/delete")
+        response_status_code, response_json = self._hit_api("DELETE", f"proof/{proof_id}/delete")
         if response_status_code != 200:
             raise Sindri.APIError(
                 f"Unable to delete proof_id={proof_id}."
@@ -538,7 +532,7 @@ class Sindri:
     def get_user_team_details(self) -> dict:
         """Get details about the user or team associated with the provided API Key."""
         if self.verbose_level > 0:
-            print(f"User/Team: Get user/team details for the provided API Key.")
+            print("User/Team: Get user/team details for the provided API Key.")
         response_status_code, response_json = self._hit_api("GET", "team/me")
         if response_status_code != 200:
             raise Sindri.APIError(

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,8 @@
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,47 @@
+# Tests for Sindri SDK
+
+These tests assume the Sindri API is functioning normally and you have a valid `SINDRI_API_KEY`.
+
+# Setup
+1. In the parent directory of this repo, clone the [sindri-resources](https://github.com/Sindri-Labs/sindri-resources) repo: `git clone https://github.com/Sindri-Labs/sindri-resources.git`
+1. Obtain a valid Sindri API Key. See [sindri.app/docs](sindri.app/docs) for more information about creating a Sindri account.
+1. Configure your python environment (see below)
+1. Configure your environment variables (see below)
+
+### Setup Virtual Environment & Install Modules
+Ensure you have a python3 environment set up with dependent modules for Sindri SDK and testing:
+- `requests`
+- `pytest`
+
+```bash
+# Create virtual environment called `venv`
+python3 -m venv venv
+# Activate virtual environment
+source venv/bin/activate
+# Install necessary modules
+pip install requests pytest
+# Run `deactivate` to deactivate virtual environment
+```
+
+### Environment Variables
+When running `pytest`, these environment variables must be set in your environment. You may prefix your command with the environment variables as well. For example: `SINDRI_API_KEY=your_api_key pytest`
+
+- `SINDRI_API_KEY=your_api_key` *Required*
+- `SINDRI_API_URL=https://sindri.app/api` *Optional. Default value shown*
+
+### Run Pytest
+You must be in the root directory of this repo: `cd ..`
+
+Here are several options for running tests with environment variables:
+
+Exporting ENVs:
+```bash
+export SINDRI_API_KEY=your_api_key
+export SINDRI_API_URL=https://sindri.app/api
+pytest
+```
+
+Prefixing ENVs:
+```bash
+SINDRI_API_KEY=your_api_key SINDRI_API_URL=https://sindri.app/api pytest
+```

--- a/tests/test_sindri.py
+++ b/tests/test_sindri.py
@@ -1,0 +1,111 @@
+import os
+import time
+
+from src.sindri.sindri import Sindri
+
+
+# Load sample data.
+# This assumes the sindri-resources repo is cloned in the parent dir of this repo
+dir_name = os.path.dirname(os.path.abspath(__file__))
+sindri_resources_path = os.path.join(dir_name, "..", "..", "sindri-resources")
+assert os.path.exists(sindri_resources_path)
+
+circuit_dir = os.path.join(sindri_resources_path, "circuit_database", "noir", "not_equal")
+proof_input_file_path = os.path.join(circuit_dir, "Prover.toml")
+assert os.path.exists(circuit_dir)
+assert os.path.exists(proof_input_file_path)
+proof_input = ""
+with open(proof_input_file_path, "r") as f:
+    proof_input = f.read()
+
+
+# Create an instance of the Sindri SDK
+api_key = os.environ.get("SINDRI_API_KEY", "unset")
+api_url = os.environ.get("SINDRI_API_URL", "https://sindri.app/api")
+sindri = Sindri(api_key, api_url=api_url, verbose_level=2)
+
+
+class TestSindriSdk:
+    """Test Sindri SDK methods.
+    
+    All methods may raise Sindri.APIError.
+    - If this error is raised, the pytest will fail as well.
+    - Tests that do not assert anything are still successful if they pass because the Sindri SDK
+    method did not raise an error.
+
+    NOTE: These current unit test not perfectly designed. Unit tests should mock calls to and
+    responses from the API. Until these unit tests are properly written, we use strategies such as
+    the one in `test_circuit_create_prove_other()` to test the functionality of the Sindri SDK
+    methods.
+    """
+    
+    def test_user_team_details(self):
+        sindri.get_user_team_details()
+
+    def test_get_all_circuits(self):
+        sindri.get_all_circuits()
+
+    def test_get_all_proofs(self):
+        sindri.get_all_proofs()
+
+    def test_circuit_create_prove_other(self):
+        """
+        Most SDK methods require a circuit and a proof to be created.
+        This test combines several tests so we only have to create 1 circuit and 1 proof.
+        The order of these steps is carefully designed so all data is available in Sindri
+        when necessary.
+        1. Test create a circuit
+        1. Test prove the circuit.
+        1. Test list circuit proofs
+        1. Test circuit detail
+        1. Test proof detail
+        1. Test delete proof
+        1. Test delete circuit
+        """
+        circuit_id = sindri.create_circuit(circuit_dir)
+        proof_id = sindri.prove_circuit(circuit_id, proof_input)
+        sindri.get_all_circuit_proofs(circuit_id)
+        sindri.get_circuit(circuit_id)
+        sindri.get_proof(proof_id)
+        sindri.delete_proof(proof_id)
+        sindri.delete_circuit(circuit_id)
+
+
+    def test_circuit_create_prove_no_wait(self):
+        """
+        This test is similar to `test_circuit_create_prove_other()`, but it supplies
+        `wait=False` to `sindri.create_circuit()` and `sindri.prove_circuit()` to ensure
+        that those methods do not poll for the result. Manually poll instead.
+        """
+        polling_interval_sec = 1.0
+        max_polling_intervals = 120
+
+        circuit_id = sindri.create_circuit(circuit_dir, wait=False)
+
+        # manually poll circuit detail until status is ready/failed
+        status = ""
+        for _ in range(0, max_polling_intervals):
+            time.sleep(polling_interval_sec)
+            status = sindri.get_circuit(circuit_id).get("status", "")
+            if status in ["Ready", "Failed"]:
+                break
+        else:
+            raise RuntimeError("Max polling reached")
+        assert status == "Ready"
+
+
+        proof_id = sindri.prove_circuit(circuit_id, proof_input)
+
+        # manually poll proof detail until status is ready/failed
+        status = ""
+        for _ in range(0, max_polling_intervals):
+            time.sleep(polling_interval_sec)
+            status = sindri.get_proof(proof_id).get("status", "")
+            if status in ["Ready", "Failed"]:
+                break
+        else:
+            raise RuntimeError("Max polling reached")
+        assert status == "Ready"
+        
+        sindri.delete_proof(proof_id)
+        sindri.delete_circuit(circuit_id)


### PR DESCRIPTION
# Add more methods and unit tests

This PR introduces new python SDK methods that implement interacting with more of the Sindri API endpoints. NOTE: All of these API endpoints are currently hidden on https://sindri.app/docs/reference/api/circuits/
- delete circuit
- delete proof
- get team detail

This PR introduces a *first draft* of pytest unit tests. #23 outlines a future update to these unit tests.

### Reviewer testing
To run the new unit tests, which also test the new methods. See `tests/README.md`.
- [ ] Run unit tests