### PR TITLE
Add smart contract and calldata retrieval functionality

### DIFF
--- a/src/sindri/sindri.py
+++ b/src/sindri/sindri.py
@@ -257,6 +257,7 @@ class Sindri:
         include_proof_input: bool = False,
         include_proof: bool = False,
         include_public: bool = False,
+        include_smart_contract_calldata: bool = False,
         include_verification_key: bool = False,
     ) -> tuple[int, dict | list]:
         """
@@ -271,9 +272,10 @@ class Sindri:
             f"proof/{proof_id}/detail",
             data={
                 "include_proof_input": include_proof_input,
-                "include_public": include_public,
-                "include_verification_key": include_verification_key,
                 "include_proof": include_proof,
+                "include_public": include_public,
+                "include_smart_contract_calldata": include_smart_contract_calldata,
+                "include_verification_key": include_verification_key,
             },
         )
 
@@ -511,13 +513,67 @@ class Sindri:
 
         return response_json
 
-    def get_proof(self, proof_id: str, include_proof_input: bool = False) -> dict:
+    def get_circuit_smart_contract_verifier(self, circuit_id: str) -> str:
+        """Get the circuit's smart contract verifier code for `circuit_id`.
+
+        Returns:
+
+        - `str`: the smart contract verifier code
+
+        Raises `Sindri.APIError` if:
+
+        - the circuit's circuit type does not support smart contract verifier generation
+        """
+        if self.verbose_level > 0:
+            print(f"Circuit: Get circuit smart contract verifier for circuit_id: {circuit_id}")
+        response_status_code, response_json = self._hit_api(
+            "GET", f"circuit/{circuit_id}/smart_contract_verifier"
+        )
+        if response_status_code != 200:
+            raise Sindri.APIError(
+                f"Unable to fetch smart contract verifier code for circuit_id={circuit_id}."
+                f" status={response_status_code} response={response_json}"
+            )
+        # Extract smart_contract_verifier_code from response and check types
+        if not isinstance(response_json, dict):
+            raise Sindri.APIError(
+                "Received unexpected type for circuit smart contract verifier response."
+            )
+        try:
+            smart_contract_verifier_code: str = response_json["contract_code"]
+        except KeyError:
+            raise Sindri.APIError(
+                "Received unexpected type for circuit smart contract verifier response."
+            )
+        if not isinstance(smart_contract_verifier_code, str):
+            raise Sindri.APIError(
+                "Received unexpected type for circuit smart contract verifier response."
+            )
+
+        if self.verbose_level == 2:
+            print(smart_contract_verifier_code)
+
+        return smart_contract_verifier_code
+
+    def get_proof(
+        self,
+        proof_id: str,
+        include_proof_input: bool = False,
+        include_smart_contract_calldata: bool = False,
+    ) -> dict:
         """
         Get proof for `proof_id`.
 
         Parameters:
 
         - `include_proof_input: bool` specifies if the proof input should also be returned.
+        - `include_smart_contract_calldata: bool` specifies if the proof + public formated as
+        calldata for the circuit's smart contract verifier should also be returned.
+
+        Raises `Sindri.APIError` if:
+
+        - `include_smart_contract_calldata=True` and the proof's circuit type does not support
+        generating calldata for its circuit's smart contract verifier
         """
         if self.verbose_level > 0:
             print(f"Proof: Get proof detail for proof_id: {proof_id}")
@@ -526,6 +582,7 @@ class Sindri:
             include_proof_input=include_proof_input,
             include_proof=True,
             include_public=True,
+            include_smart_contract_calldata=include_smart_contract_calldata,
             include_verification_key=True,
         )
         if response_status_code != 200:

--- a/tests/README.md
+++ b/tests/README.md
@@ -19,7 +19,7 @@ python3 -m venv venv
 # Activate virtual environment
 source venv/bin/activate
 # Install necessary modules
-pip install requests pytest
+pip install -U requests pytest
 # Run `deactivate` to deactivate virtual environment
 ```
 

--- a/tests/test_sindri.py
+++ b/tests/test_sindri.py
@@ -10,13 +10,24 @@ dir_name = os.path.dirname(os.path.abspath(__file__))
 sindri_resources_path = os.path.join(dir_name, "..", "..", "sindri-resources")
 assert os.path.exists(sindri_resources_path)
 
-circuit_dir = os.path.join(sindri_resources_path, "circuit_database", "noir", "not_equal")
-proof_input_file_path = os.path.join(circuit_dir, "Prover.toml")
-assert os.path.exists(circuit_dir)
-assert os.path.exists(proof_input_file_path)
-proof_input = ""
-with open(proof_input_file_path, "r") as f:
-    proof_input = f.read()
+# This Noir circuit sample data is the fastest circuit for general compile+prove testing
+noir_circuit_dir = os.path.join(sindri_resources_path, "circuit_database", "noir", "not_equal")
+noir_proof_input_file_path = os.path.join(noir_circuit_dir, "Prover.toml")
+assert os.path.exists(noir_circuit_dir)
+assert os.path.exists(noir_proof_input_file_path)
+noir_proof_input = ""
+with open(noir_proof_input_file_path, "r") as f:
+    noir_proof_input = f.read()
+
+# This Circom circuit is slightly slower to compile+prove, but it supports smart contract verifier
+# code generation and returning the proof formatted as calldata for that smart contract
+circom_circuit_dir = os.path.join(sindri_resources_path, "circuit_database", "circom", "multiplier2")
+circom_proof_input_file_path = os.path.join(circom_circuit_dir, "input.json")
+assert os.path.exists(circom_circuit_dir)
+assert os.path.exists(circom_proof_input_file_path)
+circom_proof_input = ""
+with open(circom_proof_input_file_path, "r") as f:
+    circom_proof_input = f.read()
 
 
 # Create an instance of the Sindri SDK
@@ -62,8 +73,8 @@ class TestSindriSdk:
         1. Test delete proof
         1. Test delete circuit
         """
-        circuit_id = sindri.create_circuit(circuit_dir)
-        proof_id = sindri.prove_circuit(circuit_id, proof_input)
+        circuit_id = sindri.create_circuit(noir_circuit_dir)
+        proof_id = sindri.prove_circuit(circuit_id, noir_proof_input)
         sindri.get_all_circuit_proofs(circuit_id)
         sindri.get_circuit(circuit_id)
         sindri.get_proof(proof_id)
@@ -80,7 +91,7 @@ class TestSindriSdk:
         polling_interval_sec = 1.0
         max_polling_intervals = 120
 
-        circuit_id = sindri.create_circuit(circuit_dir, wait=False)
+        circuit_id = sindri.create_circuit(noir_circuit_dir, wait=False)
 
         # manually poll circuit detail until status is ready/failed
         status = ""
@@ -94,7 +105,7 @@ class TestSindriSdk:
         assert status == "Ready"
 
 
-        proof_id = sindri.prove_circuit(circuit_id, proof_input)
+        proof_id = sindri.prove_circuit(circuit_id, noir_proof_input)
 
         # manually poll proof detail until status is ready/failed
         status = ""
@@ -107,5 +118,26 @@ class TestSindriSdk:
             raise RuntimeError("Max polling reached")
         assert status == "Ready"
         
+        sindri.delete_proof(proof_id)
+        sindri.delete_circuit(circuit_id)
+
+
+    def test_circuit_create_prove_smart_contract_calldata(self):
+        """
+        Most SDK methods require a circuit and a proof to be created.
+        This test combines several tests so we only have to create 1 circuit and 1 proof.
+        The order of these steps is carefully designed so all data is available in Sindri
+        when necessary.
+        1. Test create a circuit
+        1. Test prove the circuit.
+        1. Test fetching the circuit's smart contract verifier code
+        1. Test proof detail with including the proof calldata
+        1. Test delete proof
+        1. Test delete circuit
+        """
+        circuit_id = sindri.create_circuit(circom_circuit_dir)
+        proof_id = sindri.prove_circuit(circuit_id, circom_proof_input)
+        sindri.get_circuit_smart_contract_verifier(circuit_id)
+        sindri.get_proof(proof_id, include_smart_contract_calldata=True)
         sindri.delete_proof(proof_id)
         sindri.delete_circuit(circuit_id)


### PR DESCRIPTION
# Add smart contract and calldata retrieval functionality

closes #22 

### New Sindri API Functionality
For select circuit types and curves, the Sindri API will now
- generate a smart contract verifier during the compile phase and return the code for it in a new [endpoint ](https://sindri.app/api/docs#/internal/circuit-smart-contract-verifier)
- format the proof+public as calldata for the aforementioned smart contract verifier

### This PR 
This PR adds SDK functionality to support new Sindri API functionality above.
- Add a [new method](https://github.com/Sindri-Labs/sindri-python/pull/27/files#diff-d6ea7e6fc2faefc60dbe92247620b13c74212f731b76588bb466e174d93d2ab6R516) to fetch a circuit's smart contract verifier code
- Add an optional [parameter](https://github.com/Sindri-Labs/sindri-python/pull/27/files#diff-d6ea7e6fc2faefc60dbe92247620b13c74212f731b76588bb466e174d93d2ab6R562) to the `get_proof()` method to return the proof+public as calldata
- Adds a unit test for the above


### Reviewer testing instructions
- [ ] Run unit tests. See `tests/README.md` for instructions.