### PR TITLE
Fix docs build

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           python-version: 3.10.6
       - run: |
-          pip install requests>=2.13.0 lazydocs
+          pip install requests>=2.13.0 lazydocs==0.4.8
       - run: |
           TAG=${{ github.ref_name }} ./build-docs.sh
 

--- a/build-docs.sh
+++ b/build-docs.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
+
+set -e
+
 mkdir -p docs/docstrings
 
 TAG="${TAG:-main}"
 
-# pip install requests>=2.13.0 lazydocs
+# pip install requests>=2.13.0 lazydocs==0.4.8
 lazydocs \
     --output-path="docs/docstrings" \
     --overview-file="README.md" \
     --src-base-url="https://github.com/Sindri-Labs/sindri-python/blob/$TAG/" \
     --no-watermark \
-    src/sindri
+    src/sindri/sindri.py

--- a/local-run-docs.sh
+++ b/local-run-docs.sh
@@ -1,16 +1,19 @@
 #!/usr/bin/env bash
+
+set -e
+
 mkdir -p docs/docstrings
 
 
 TAG="${TAG:-main}"
 
-# pip install requests>=2.13.0 lazydocs
+# pip install requests>=2.13.0 lazydocs==0.4.8
 lazydocs \
     --output-path="./docs/docstrings" \
     --overview-file="README.md" \
     --src-base-url="https://github.com/Sindri-Labs/sindri-python/blob/$TAG/" \
     --no-watermark \
-    src/sindri
+    src/sindri/sindri.py
 
 # pip install mkdocs mkdocs-awesome-pages-plugin
 echo "Hosting docs on http://localhost:1111"


### PR DESCRIPTION
The docs build was not working with the introduction of `src/sindri/__init__.py` in #24 

This PR fixes it by specifying the path to the python module we want to generate docs for.

This also locks the version of `lazydocs` that we install.