### PR TITLE
Fix docs build attempt three

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -24,7 +24,7 @@ jobs:
         run: poetry install
 
       - run: |
-          TAG=${{ github.ref_name }} ./build-docs.sh
+          TAG=${{ github.ref_name }} poetry run ./build-docs.sh
 
       - name: 'Save Generated Markdown'
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Fix docs build attempt three

- use `poetry run` to activate the `poetry` environment in the github action