### PR TITLE
Remove outdated variable

### DIFF
--- a/src/sindri/sindri.py
+++ b/src/sindri/sindri.py
@@ -77,7 +77,6 @@ class Sindri:
 
         self.polling_interval_sec: int = 1  # polling interval for circuit compilation & proving
         self.max_polling_iterations: int = 172800  # 2 days with polling interval 1 second
-        self.perform_verify: bool = False
 
         self._api_url = self._get_api_url(**kwargs)
         self.set_api_key(api_key)


### PR DESCRIPTION
This PR is a one-liner that removes an outdated variable that was left in by mistake.