### PR TITLE
Update dependency versions for CI actions

### DIFF
--- a/.github/workflows/build-publish-pypi.yml
+++ b/.github/workflows/build-publish-pypi.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set Up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -12,8 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.10.6
 
@@ -27,7 +27,7 @@ jobs:
           TAG=${{ github.ref_name }} poetry run ./build-docs.sh
 
       - name: 'Save Generated Markdown'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: generated_docs
           path: ./docs/docstrings/*


### PR DESCRIPTION
Update dependency versions for CI actions
closes #51 

Just that. Some CI dependencies raised warnings that they were deprecated.