### PR TITLE
Add meta field to compile/prove endpoint methods

### DIFF
--- a/src/sindri/sindri.py
+++ b/src/sindri/sindri.py
@@ -350,7 +350,11 @@ class Sindri:
         }
 
     def create_circuit(
-        self, circuit_upload_path: str, tags: list[str] | None = None, wait: bool = True
+        self,
+        circuit_upload_path: str,
+        tags: list[str] | None = None,
+        wait: bool = True,
+        meta: dict | None = None,
     ) -> str:
         """Create a circuit. For information, refer to the
         [API docs](https://sindri.app/docs/reference/api/circuit-create/).
@@ -359,6 +363,9 @@ class Sindri:
         - `circuit_upload_path`: The path to either
             - A directory containing your circuit files
             - A compressed file (`.tar.gz` or `.zip`) of your circuit directory
+        - `meta`: An arbitrary mapping of metadata keys to string values.
+        This can be used to track additional information about the circuit such as an ID
+        from an external system.
         - `tags`: A list of tags to assign the circuit. Defaults to `["latest"]` if not
         sepecified.
         - `wait`:
@@ -405,7 +412,10 @@ class Sindri:
         response_status_code, response_json = self._hit_api(
             "POST",
             "circuit/create",
-            data={"tags": tags},
+            data={
+                "tags": tags,
+                "meta": json.dumps(meta),
+            },
             files=files,
         )
         if response_status_code != 201:
@@ -740,6 +750,7 @@ class Sindri:
         proof_input: str,
         perform_verify: bool = False,
         wait: bool = True,
+        meta: dict | None = None,
         **kwargs,
     ) -> str:
         """Prove a circuit with specified inputs. For information, refer to the
@@ -747,6 +758,8 @@ class Sindri:
 
         Args:
         - `circuit_id`: The circuit identifier of the circuit.
+        - `meta`: An arbitrary mapping of metadata keys to string values. This can be used to
+        track additional information about the proof such as an ID from an external system.
         - `proof_input`: A string representing proof input which may be formatted as JSON for any
         framework. Noir circuits optionally accept TOML formatted proof input.
         - `perform_verify`: A boolean indicating whether to perform an internal verification check
@@ -783,6 +796,7 @@ class Sindri:
                 "proof_input": proof_input,
                 "perform_verify": perform_verify,
                 "prover_implementation": prover_implementation,
+                "meta": json.dumps(meta),
             },
         )
         if response_status_code != 201:

--- a/src/sindri/sindri.py
+++ b/src/sindri/sindri.py
@@ -408,9 +408,11 @@ class Sindri:
                 tar.add(circuit_upload_path, arcname=file_name)
             files = {"files": fh.getvalue()}  # type: ignore
 
-        data = {"tags": tags}
+        data = {
+            "tags": tags,
+        }
         if meta is not None:
-            data["meta"] = json.dumps(meta)
+            data["meta"] = json.dumps(meta)  # type: ignore
         # Hit circuit/create API endpoint
         response_status_code, response_json = self._hit_api(
             "POST",

--- a/src/sindri/sindri.py
+++ b/src/sindri/sindri.py
@@ -408,14 +408,14 @@ class Sindri:
                 tar.add(circuit_upload_path, arcname=file_name)
             files = {"files": fh.getvalue()}  # type: ignore
 
+        data = {"tags": tags}
+        if meta is not None:
+            data["meta"] = json.dumps(meta)
         # Hit circuit/create API endpoint
         response_status_code, response_json = self._hit_api(
             "POST",
             "circuit/create",
-            data={
-                "tags": tags,
-                "meta": json.dumps(meta),
-            },
+            data=data,
             files=files,
         )
         if response_status_code != 201:
@@ -788,16 +788,18 @@ class Sindri:
         # 1. Submit a proof, obtain a proof_id.
         if self.verbose_level > 0:
             print("Prove circuit")
+
+        data = {
+            "proof_input": proof_input,
+            "perform_verify": perform_verify,
+            "prover_implementation": prover_implementation,
+        }
+        if meta is not None:
+            data["meta"] = json.dumps(meta)
+
         # Hit the circuit/<circuit_id>/prove endpoint
         response_status_code, response_json = self._hit_api(
-            "POST",
-            f"circuit/{circuit_id}/prove",
-            data={
-                "proof_input": proof_input,
-                "perform_verify": perform_verify,
-                "prover_implementation": prover_implementation,
-                "meta": json.dumps(meta),
-            },
+            "POST", f"circuit/{circuit_id}/prove", data=data
         )
         if response_status_code != 201:
             raise Sindri.APIError(

--- a/tests/test_sindri.py
+++ b/tests/test_sindri.py
@@ -73,7 +73,9 @@ class TestSindriSdk:
         1. Test delete proof
         1. Test delete circuit
         """
-        circuit_id = sindri.create_circuit(noir_circuit_dir, tags=["latest", "pytest"], meta={"py-sdk": "pytest"})
+        circuit_id = sindri.create_circuit(
+            noir_circuit_dir, tags=["latest", "pytest"], meta={"py-sdk": "pytest"}
+        )
         proof_id = sindri.prove_circuit(circuit_id, noir_proof_input, meta={"py-sdk": "pytest"})
         sindri.get_all_circuit_proofs(circuit_id)
         sindri.get_circuit(circuit_id)

--- a/tests/test_sindri.py
+++ b/tests/test_sindri.py
@@ -73,8 +73,8 @@ class TestSindriSdk:
         1. Test delete proof
         1. Test delete circuit
         """
-        circuit_id = sindri.create_circuit(noir_circuit_dir)
-        proof_id = sindri.prove_circuit(circuit_id, noir_proof_input)
+        circuit_id = sindri.create_circuit(noir_circuit_dir, tags=["latest", "pytest"], meta={"py-sdk": "pytest"})
+        proof_id = sindri.prove_circuit(circuit_id, noir_proof_input, meta={"py-sdk": "pytest"})
         sindri.get_all_circuit_proofs(circuit_id)
         sindri.get_circuit(circuit_id)
         sindri.get_proof(proof_id)


### PR DESCRIPTION
This adds support for specifying arbitrary key/value string pairs as metadata attached to a circuit or proof. This can be used for a variety of purposes like tracking which individual user on a team submitted a proof or storing database IDs from an external system.