### PR TITLE
Fix python version in github action for pypi build

### DIFF
--- a/.github/workflows/build-publish-pypi.yml
+++ b/.github/workflows/build-publish-pypi.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set Up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.8.1'
+          python-version: 3.10.6
 
       - name: Extract Version from Tag
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV


### PR DESCRIPTION
#42 Introduced an [error](https://github.com/Sindri-Labs/sindri-python/actions/runs/12587325754/job/35082946169#step:3:11) in the PyPI GHA build. This PR [reverts](https://github.com/Sindri-Labs/sindri-python/pull/59/files#diff-09c0d700ec41cdcde19c17c79874f03c470dad739223d2146a4a2593f32bc9aeL25-R25) changing the python version in the GHA. Note this does not affect the minimum python requirement for the published PyPI package.