### PR TITLE
Check finished_processing bool instead of status str when polling for completion

### DIFF
--- a/.github/workflows/build-publish-pypi.yml
+++ b/.github/workflows/build-publish-pypi.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set Up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.8.1'
+          python-version: 3.10.6
 
       - name: Extract Version from Tag
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV

--- a/.github/workflows/build-publish-pypi.yml
+++ b/.github/workflows/build-publish-pypi.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set Up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.10.6
+          python-version: '3.8.1'
 
       - name: Extract Version from Tag
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV


### PR DESCRIPTION
closes #57 

- [x] `pytest` succeeds, which confirms the new polling logic is working because it creates circuits and proofs and polls until they are finished processing.
- [x] `sh py_format_code.sh` succeeds